### PR TITLE
Remove simply from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For content or product suggestions, please use the appropriate channels, usually
 
 ## Submitting Ideas
 
-Simply navigate to [**Issues**](https://github.com/MicrosoftDocs/feedback/issues) and open a new issue with all the relevant details. We will triage those as soon as possible.
+Navigate to [**Issues**](https://github.com/MicrosoftDocs/feedback/issues) and open a new issue with all the relevant details. We will triage those as soon as possible.
 
 ![Adding a GitHub issue](img/add-issue.gif)
 


### PR DESCRIPTION
https://microsoft-ce-csi.acrolinx.cloud/htmldata/en/rules/help/avoid_simply.html
Avoid "simple/simply"
It's generally a good idea to avoid describing instructions with simple or simply as the reader might not find it so simple.
Avoid unnecessary words that don't add meaning to the text.