### PR TITLE
Fix Welcome Bot Support Link

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,2 +1,5 @@
 newIssueWelcomeComment: >
-  Thank you for creating the issue! One of our team members will get back to you shortly with additional information. If this is a product issue, please close this and contact the particular product's support instead (see https://support.microsoft.com/allproducts for the list of support websites).
+  Thank you for opening an issue! One of our team members will get back to you shortly with additional information.
+
+
+  If this is a product issue, please close this issue and contact the particular product's support instead. For a list of support websites, see [Support for Microsoft products and apps](https://support.microsoft.com/all-products).

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,5 +1,5 @@
 newIssueWelcomeComment: >
-  Thank you for opening an issue! One of our team members will get back to you shortly with additional information.
-
-
-  If this is a product issue, please close this issue and contact the particular product's support instead. For a list of support websites, see [Support for Microsoft products and apps](https://support.microsoft.com/all-products).
+  Thank you for opening an issue! One of our team members will get back to you with additional information.
+    
+  If this is a product issue, please close this issue and contact the product's support instead. For a list of support websites, see [Support for Microsoft products and apps](https://support.microsoft.com/all-products).
+  


### PR DESCRIPTION
### Description

- Closes #3813 

As described in #3813 the support link is wrong. I made a few other small changes, such as making the support link a markdown link with text. Here is what it will look like.

![Fixed Welcome Bot Support Link](https://user-images.githubusercontent.com/10838153/173507638-c8312634-185c-426c-ba5d-70a05fcb846d.png)


If maintainers want to further make changes to the comment, this branch allows edits from maintainers.